### PR TITLE
Fix findNearestPoly result handling in Crowd (closes #55)

### DIFF
--- a/detour/src/main/java/org/recast4j/detour/NavMeshQuery.java
+++ b/detour/src/main/java/org/recast4j/detour/NavMeshQuery.java
@@ -521,7 +521,7 @@ public class NavMeshQuery {
     /// @returns The status flags for the query.
     public Result<FindNearestPolyResult> findNearestPoly(float[] center, float[] halfExtents, QueryFilter filter) {
 
-        float[] nearestPt = null;
+        float[] nearestPt = new float[] {center[0], center[1], center[2]};
 
         // Get nearby polygons from proximity grid.
         Result<List<Long>> polysResult = queryPolygons(center, halfExtents, filter);

--- a/detour/src/test/java/org/recast4j/detour/FindNearestPolyTest.java
+++ b/detour/src/test/java/org/recast4j/detour/FindNearestPolyTest.java
@@ -44,4 +44,32 @@ public class FindNearestPolyTest extends AbstractDetourTest {
         }
 
     }
+
+    @Test
+    public void shouldReturnStartPosWhenNoPolyIsValid() {
+        QueryFilter filter = new QueryFilter() {
+            @Override
+            public boolean passFilter(long ref, MeshTile tile, Poly poly) {
+                return false;
+            }
+
+            @Override
+            public float getCost(float[] pa, float[] pb, long prevRef, MeshTile prevTile,
+                                 Poly prevPoly, long curRef, MeshTile curTile, Poly curPoly,
+                                 long nextRef, MeshTile nextTile, Poly nextPoly) {
+                return 0;
+            }
+        };
+        float[] extents = { 2, 4, 2 };
+        for (int i = 0; i < startRefs.length; i++) {
+            float[] startPos = startPoss[i];
+            Result<FindNearestPolyResult> poly = query.findNearestPoly(startPos, extents, filter);
+            assertTrue(poly.succeeded());
+            Assert.assertEquals(0L, poly.result.getNearestRef());
+            for (int v = 0; v < polyPos[i].length; v++) {
+                Assert.assertEquals(startPos[v], poly.result.getNearestPos()[v], 0.001f);
+            }
+        }
+
+    }
 }


### PR DESCRIPTION
In case there are no valid polys (i.e. all polygons are filtered out)
findNearestPoly will still return success yet the nearestPos field will
not be populated leading to NPE.