### PR TITLE
Warn about overlapping regions instead of throwing an error

### DIFF
--- a/recast/src/main/java/org/recast4j/recast/RecastRegion.java
+++ b/recast/src/main/java/org/recast4j/recast/RecastRegion.java
@@ -1446,7 +1446,7 @@ public class RecastRegion {
 
         // If overlapping regions were found during merging, split those regions.
         if (overlaps.size() > 0) {
-            throw new RuntimeException("rcBuildRegions: " + overlaps.size() + " overlapping regions.");
+            ctx.warn("rcBuildRegions: " + overlaps.size() + " overlapping regions.");
         }
 
         ctx.stopTimer("BUILD_REGIONS_FILTER");


### PR DESCRIPTION
Resolves Recast4j issue https://github.com/ppiastucki/recast4j/issues/71.