### PR TITLE
Fix A* Pathfinding importer to set agent dimension

### DIFF
--- a/detour-extras/src/main/java/org/recast4j/detour/extras/unity/astar/GraphMeshDataReader.java
+++ b/detour-extras/src/main/java/org/recast4j/detour/extras/unity/astar/GraphMeshDataReader.java
@@ -132,6 +132,9 @@ class GraphMeshDataReader extends BinaryReader {
                         + meta.cellSize * meta.tileSizeZ * (z + 1);
                 header.bvQuantFactor = 1.0f / meta.cellSize;
                 header.offMeshBase = nodeCount;
+                header.walkableClimb = meta.walkableClimb;
+                header.walkableHeight = meta.walkableHeight;
+                header.walkableRadius = meta.characterRadius;
                 tiles[tileIndex].header = header;
             }
         }


### PR DESCRIPTION
Detour requires e.g. walkableClimb to be able to build external links between tiles