### PR TITLE
chore: Change TriMesh to interface and rework PartitionedMesh

### DIFF
--- a/recast-demo/src/main/java/org/recast4j/demo/geom/DemoInputGeomProvider.java
+++ b/recast-demo/src/main/java/org/recast4j/demo/geom/DemoInputGeomProvider.java
@@ -31,6 +31,7 @@ import org.recast4j.recast.AreaModification;
 import org.recast4j.recast.ConvexVolume;
 import org.recast4j.recast.RecastVectors;
 import org.recast4j.recast.geom.InputGeomProvider;
+import org.recast4j.recast.geom.PartitionedMesh;
 import org.recast4j.recast.geom.TriMesh;
 
 public class DemoInputGeomProvider implements InputGeomProvider {
@@ -121,7 +122,7 @@ public class DemoInputGeomProvider implements InputGeomProvider {
 
     @Override
     public Iterable<TriMesh> meshes() {
-        return Collections.singletonList(new TriMesh(vertices, faces));
+        return Collections.singletonList(new PartitionedMesh(vertices, faces));
     }
 
     public List<DemoOffMeshConnection> getOffMeshConnections() {

--- a/recast/src/main/java/org/recast4j/recast/RecastVoxelization.java
+++ b/recast/src/main/java/org/recast4j/recast/RecastVoxelization.java
@@ -20,7 +20,6 @@ package org.recast4j.recast;
 
 import java.util.List;
 
-import org.recast4j.recast.geom.PartitionedMesh.PartitionedMeshNode;
 import org.recast4j.recast.geom.InputGeomProvider;
 import org.recast4j.recast.geom.TriMesh;
 
@@ -53,9 +52,8 @@ public class RecastVoxelization {
                 tbmin[1] = builderCfg.bmin[2];
                 tbmax[0] = builderCfg.bmax[0];
                 tbmax[1] = builderCfg.bmax[2];
-                List<PartitionedMeshNode> nodes = geom.getChunksOverlappingRect(tbmin, tbmax);
-                for (PartitionedMeshNode node : nodes) {
-                    int[] tris = node.tris;
+                List<int[]> overlappingTris = geom.getChunksOverlappingRect(tbmin, tbmax);
+                for (int[] tris : overlappingTris) {
                     int ntris = tris.length / 3;
                     int[] m_triareas = Recast.markWalkableTriangles(ctx, cfg.walkableSlopeAngle, verts, tris, ntris,
                             cfg.walkableAreaMod);

--- a/recast/src/main/java/org/recast4j/recast/geom/NthElement.java
+++ b/recast/src/main/java/org/recast4j/recast/geom/NthElement.java
@@ -1,0 +1,83 @@
+/*
+recast4j copyright (c) 2021-2026 Piotr Piastucki piotr@recast4j.org
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+1. The origin of this software must not be misrepresented; you must not
+ claim that you wrote the original software. If you use this software
+ in a product, an acknowledgment in the product documentation would be
+ appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+ misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+*/
+
+package org.recast4j.recast.geom;
+
+import java.util.Comparator;
+
+public class NthElement {
+
+    public static <T> void nthElement(T[] array, int low, int nth, int high, Comparator<? super T> comparator) {
+        while ((high - low) > 3) {
+            T midValue = medianOfThree(array[low], array[low + ((high - low) >> 1)], array[high - 1], comparator);
+            int first = low;
+            int last = high;
+            for (;;) {
+                while (comparator.compare(array[first], midValue) < 0) {
+                    first++;
+                }
+                do {
+                    last--;
+                } while (comparator.compare(midValue, array[last]) < 0);
+                if (first >= last) {
+                    break;
+                }
+                T temp = array[first];
+                array[first] = array[last];
+                array[last] = temp;
+                first++;
+            }
+            if (first <= nth) {
+                low = first;
+            } else {
+                high = first;
+            }
+        }
+        insertionSort(array, low, high, comparator);
+    }
+
+    private static <T> void insertionSort(T[] array, int low, int high, Comparator<? super T> comparator) {
+        for (int i = low + 1; i < high; i++) {
+            T key = array[i];
+            int j = i - 1;
+            while (j >= low && comparator.compare(array[j], key) > 0) {
+                array[j + 1] = array[j];
+                j--;
+            }
+            array[j + 1] = key;
+        }
+    }
+
+    private static <T> T medianOfThree(T a, T b, T c, Comparator<? super T> comparator) {
+        if (comparator.compare(a, b) < 0) {
+            if (comparator.compare(b, c) < 0) {
+                return b;
+            } else if (comparator.compare(a, c) < 0) {
+                return c;
+            } else {
+                return a;
+            }
+        } else if (comparator.compare(a, c) < 0) {
+            return a;
+        } else if (comparator.compare(b, c) < 0) {
+            return c;
+        }
+        return b;
+    }
+
+}

--- a/recast/src/main/java/org/recast4j/recast/geom/PartitionedMesh.java
+++ b/recast/src/main/java/org/recast4j/recast/geom/PartitionedMesh.java
@@ -19,11 +19,14 @@ freely, subject to the following restrictions:
 package org.recast4j.recast.geom;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-public class PartitionedMesh {
+public class PartitionedMesh implements TriMesh {
+
+    private final float[] verts;
+    private final int[] tris;
+    private final List<PartitionedMeshNode> nodes;
 
     private static class BoundsItem {
         private final float[] bmin = new float[2];
@@ -31,7 +34,7 @@ public class PartitionedMesh {
         private int i;
     }
 
-    public static class PartitionedMeshNode {
+    private static class PartitionedMeshNode {
         private final float[] bmin = new float[2];
         private final float[] bmax = new float[2];
         private int i;
@@ -51,10 +54,6 @@ public class PartitionedMesh {
             return Float.compare(a.bmin[1], b.bmin[1]);
         }
     }
-
-    List<PartitionedMeshNode> nodes;
-    int ntris;
-    int maxTrisPerChunk;
 
     private void calcExtends(BoundsItem[] items, int imin, int imax, float[] bmin, float[] bmax) {
         bmin[0] = items[imin].bmin[0];
@@ -113,15 +112,8 @@ public class PartitionedMesh {
 
             int axis = longestAxis(node.bmax[0] - node.bmin[0], node.bmax[1] - node.bmin[1]);
 
-            if (axis == 0) {
-                Arrays.sort(items, imin, imax, new CompareItemX());
-                // Sort along x-axis
-            } else if (axis == 1) {
-                Arrays.sort(items, imin, imax, new CompareItemY());
-                // Sort along y-axis
-            }
-
             int isplit = imin + inum / 2;
+            NthElement.nthElement(items, imin, isplit, imax, axis == 0 ? new CompareItemX(): new CompareItemY());
 
             // Left
             subdivide(items, imin, isplit, trisPerChunk, nodes, inTris);
@@ -133,11 +125,17 @@ public class PartitionedMesh {
         }
     }
 
-    public PartitionedMesh(float[] verts, int[] tris, int ntris, int trisPerChunk) {
+    public PartitionedMesh(float[] verts, int[] tris) {
+        this(verts, tris, 32);
+    }
+
+    public PartitionedMesh(float[] verts, int[] tris, int trisPerChunk) {
+        this.verts = verts;
+        this.tris = tris;
+        int ntris = tris.length / 3;
         int nchunks = (ntris + trisPerChunk - 1) / trisPerChunk;
 
         nodes = new ArrayList<>(nchunks);
-        this.ntris = ntris;
 
         // Build tree
         BoundsItem[] items = new BoundsItem[ntris];
@@ -169,18 +167,6 @@ public class PartitionedMesh {
 
         subdivide(items, 0, ntris, trisPerChunk, nodes, tris);
 
-        // Calc max tris per node.
-        maxTrisPerChunk = 0;
-        for (PartitionedMeshNode node : nodes) {
-            boolean isLeaf = node.i >= 0;
-            if (!isLeaf) {
-                continue;
-            }
-            if (node.tris.length / 3 > maxTrisPerChunk) {
-                maxTrisPerChunk = node.tris.length / 3;
-            }
-        }
-
     }
 
     private boolean checkOverlapRect(float[] amin, float[] amax, float[] bmin, float[] bmax) {
@@ -190,9 +176,9 @@ public class PartitionedMesh {
         return overlap;
     }
 
-    public List<PartitionedMeshNode> getChunksOverlappingRect(float[] bmin, float[] bmax) {
-        // Traverse tree
-        List<PartitionedMeshNode> ids = new ArrayList<>();
+    @Override
+    public List<int[]> getChunksOverlappingRect(float[] bmin, float[] bmax) {
+        List<int[]> ids = new ArrayList<>();
         int i = 0;
         while (i < nodes.size()) {
             PartitionedMeshNode node = nodes.get(i);
@@ -200,7 +186,7 @@ public class PartitionedMesh {
             boolean isLeafNode = node.i >= 0;
 
             if (isLeafNode && overlap) {
-                ids.add(node);
+                ids.add(node.tris);
             }
 
             if (overlap || isLeafNode) {
@@ -210,6 +196,16 @@ public class PartitionedMesh {
             }
         }
         return ids;
+    }
+
+    @Override
+    public int[] getTris() {
+        return tris;
+    }
+
+    @Override
+    public float[] getVerts() {
+        return verts;
     }
 
 }

--- a/recast/src/main/java/org/recast4j/recast/geom/SimpleInputGeomProvider.java
+++ b/recast/src/main/java/org/recast4j/recast/geom/SimpleInputGeomProvider.java
@@ -96,7 +96,7 @@ public class SimpleInputGeomProvider implements InputGeomProvider {
 
     @Override
     public Iterable<TriMesh> meshes() {
-        return Collections.singletonList(new TriMesh(vertices, faces));
+        return Collections.singletonList(new PartitionedMesh(vertices, faces));
     }
 
     public void calculateNormals() {

--- a/recast/src/main/java/org/recast4j/recast/geom/SingleTrimeshInputGeomProvider.java
+++ b/recast/src/main/java/org/recast4j/recast/geom/SingleTrimeshInputGeomProvider.java
@@ -39,7 +39,7 @@ public class SingleTrimeshInputGeomProvider implements InputGeomProvider {
             RecastVectors.min(bmin, vertices, i * 3);
             RecastVectors.max(bmax, vertices, i * 3);
         }
-        meshes = Collections.singletonList(new TriMesh(vertices, faces));
+        meshes = Collections.singletonList(new PartitionedMesh(vertices, faces));
     }
 
     @Override

--- a/recast/src/main/java/org/recast4j/recast/geom/TriMesh.java
+++ b/recast/src/main/java/org/recast4j/recast/geom/TriMesh.java
@@ -20,30 +20,12 @@ package org.recast4j.recast.geom;
 
 import java.util.List;
 
-import org.recast4j.recast.geom.PartitionedMesh.PartitionedMeshNode;
+public interface TriMesh {
 
-public class TriMesh {
+    int[] getTris();
 
-    private final float[] vertices;
-    private final int[] faces;
-    private final PartitionedMesh chunkyTriMesh;
+    float[] getVerts();
 
-    public TriMesh(float[] vertices, int[] faces) {
-        this.vertices = vertices;
-        this.faces = faces;
-        chunkyTriMesh = new PartitionedMesh(vertices, faces, faces.length / 3, 32);
-    }
-
-    public int[] getTris() {
-        return faces;
-    }
-
-    public float[] getVerts() {
-        return vertices;
-    }
-
-    public List<PartitionedMeshNode> getChunksOverlappingRect(float[] bmin, float[] bmax) {
-        return chunkyTriMesh.getChunksOverlappingRect(bmin, bmax);
-    }
+    List<int[]> getChunksOverlappingRect(float[] bmin, float[] bmax);
 
 }

--- a/recast/src/test/java/org/recast4j/recast/geom/NthElementTest.java
+++ b/recast/src/test/java/org/recast4j/recast/geom/NthElementTest.java
@@ -1,0 +1,80 @@
+package org.recast4j.recast.geom;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Random;
+
+import org.junit.jupiter.api.Test;
+
+public class NthElementTest {
+
+    @Test
+    public void testNthElementSimple() {
+        Integer[] a = {5, 3, 1, 4, 2};
+        NthElement.nthElement(a, 0, 2, a.length, Comparator.naturalOrder());
+        Integer[] sorted = a.clone();
+        Arrays.sort(sorted);
+        assertEquals(sorted[2], a[2]);
+        // partition property
+        for (int i = 0; i < 2; i++) {
+            assertTrue(a[i].compareTo(a[2]) <= 0, "element before nth should be <= nth");
+        }
+        for (int i = 3; i < a.length; i++) {
+            assertTrue(a[2].compareTo(a[i]) <= 0, "element after nth should be >= nth");
+        }
+    }
+
+    @Test
+    public void testNthElementRandom() {
+        Random rnd = new Random(12345);
+        for (int size = 1; size < 100; size++) {
+            Integer[] a = new Integer[size];
+            for (int i = 0; i < size; i++) {
+                a[i] = rnd.nextInt(1000) - 500; // include negatives
+            }
+            Integer[] sorted = a.clone();
+            Arrays.sort(sorted);
+            for (int n = 0; n < size; n++) {
+                Integer[] copy = a.clone();
+                NthElement.nthElement(copy, 0, n, copy.length, Comparator.naturalOrder());
+                assertEquals(sorted[n], copy[n], "nth element should match sorted value for size=" + size + " n=" + n);
+                // partition property
+                for (int i = 0; i < n; i++) {
+                    assertTrue(copy[i].compareTo(copy[n]) <= 0);
+                }
+                for (int i = n + 1; i < size; i++) {
+                    assertTrue(copy[n].compareTo(copy[i]) <= 0);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testNthElementWithDuplicatesAndComparator() {
+        class Item {
+            final int key;
+            final String id;
+            Item(int k, String id) { key = k; this.id = id; }
+        }
+
+        Item[] items = new Item[] {
+                new Item(2, "a"), new Item(1, "b"), new Item(2, "c"), new Item(3, "d"), new Item(1, "e")
+        };
+        Comparator<Item> comp = Comparator.comparingInt(i -> i.key);
+        Item[] expected = items.clone();
+        Arrays.sort(expected, comp);
+        NthElement.nthElement(items, 0, 2, items.length, comp);
+        assertEquals(expected[2].key, items[2].key);
+        // ensure partition property holds for keys
+        for (int i = 0; i < 2; i++) {
+            assertTrue(items[i].key <= items[2].key);
+        }
+        for (int i = 3; i < items.length; i++) {
+            assertTrue(items[2].key <= items[i].key);
+        }
+    }
+
+}


### PR DESCRIPTION
Change TriMesh to interface to make it easy to provide own mesh suppliers. 
Optimize PartitionedMesh by replacing sort with nth_element.